### PR TITLE
Change logic of t/03_spaces.t.

### DIFF
--- a/t/03_spaces.t
+++ b/t/03_spaces.t
@@ -15,6 +15,10 @@ plan tests => (1 + (keys %{$manifest}));
 ok(1);
 
 foreach my $filename (sort keys %{$manifest}) {
+    if (!$ENV{VERILATOR_AUTHOR_SITE}) {
+	skip("author only test (harmless)",1);
+	next;
+    }
     if ($filename =~ /README/) {  # May not even exist
 	skip("File doesn't need check (harmless)",1);
 	next;
@@ -28,8 +32,6 @@ foreach my $filename (sort keys %{$manifest}) {
     } elsif ($filename =~ m!\.out!
 	     || $filename =~ m!/gen/!) {
 	skip("File doesn't need check (harmless)",1);
-    } elsif (!$ENV{VERILATOR_AUTHOR_SITE}) {
-	skip("author only test (harmless)",1);
     } else {
 	warn "%Error: $filename: Bad indentation\n";
 	ok(0);


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Verilog-Perl.
We thought you might be interested in it too.

    Description: Change logic of t/03_spaces.t.
     Check for $ENV{VERILATOR_AUTHOR_SITE} first,
     before trying to read a file with wholefile().
     The latter, in the Debian case, can fail if .gitignore is missing; e.g.
     https://buildd.debian.org/status/fetch.php?pkg=libverilog-perl&arch=amd64&ver=3.480-1&stamp=1662307469&raw=0
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2022-09-04
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libverilog-perl/raw/master/debian/patches/author-tests.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
